### PR TITLE
Connection.enableDebugging(true,null) now fixed

### DIFF
--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -1491,7 +1491,7 @@ public class Connection
 		{
 			if (logger == null)
 			{
-				logger = new DebugLogger()
+				Logger.logger = new DebugLogger()
 				{
 
 					public void log(int level, String className, String message)


### PR DESCRIPTION
when a null logger was passed before it would just assign the parameter variable instead of the indended logger that is used